### PR TITLE
batch metrics on send, update tests & bump version

### DIFF
--- a/hg_agent_forwarder/forwarder.py
+++ b/hg_agent_forwarder/forwarder.py
@@ -32,7 +32,6 @@ class MetricForwarder(threading.Thread):
         self.spool_reader = SpoolReader('/var/opt/hg-agent/spool/*.spool.*',
                                         progresses=self.progress,
                                         shutdown=self.shutdown_e)
-
         self.progress_writer = ProgressWriter(self.config,
                                               self.spool_reader,
                                               self.shutdown_e)
@@ -43,6 +42,11 @@ class MetricForwarder(threading.Thread):
         self.backoff = False
         self.request_session = requests.Session()
         self.request_session.auth = HTTPBasicAuth(self.api_key, '')
+        self.batch = ""
+        self.batch_size = 0
+        self.batch_time = time.time()
+        self.batch_timeout = config.get('batch_timeout', 0.5)
+        self.max_batch_size = config.get('max_batch_size', 250)
 
     def run(self):
         while not self.shutdown_e.is_set():
@@ -50,20 +54,55 @@ class MetricForwarder(threading.Thread):
                 for line in self.spool_reader.read():
                     datapoint = Datapoint(line, self.api_key)
                     if datapoint.validate():
-                        self.forward(datapoint)
+                        self.extend_batch(datapoint)
                     else:
                         logging.error("Invalid line in spool.")
                         # invalid somehow, pass
                         continue
+                    if self.should_send_batch():
+                        self.forward()
                 if self.shutdown_e.is_set():
                     break
             except Exception as e:
                 continue
 
-    def forward(self, data):
+    def extend_batch(self, data):
+        '''
+        Add a metric to the current metric batch.
+        '''
+        if not self.batch_time:
+            self.batch_time = time.time()
+
+        try:
+            metric = data.metric
+            value = data.value
+            ts = data.timestamp
+        except AttributeError:
+            # somehow, this dp is invalid, pass it by.
+            return True
+
+        metric_str = "%s %s %s" % (metric, value, ts)
+        self.batch = "%s\n%s" % (self.batch, metric_str)
+        self.batch_size += 1
+
+    def should_send_batch(self):
+        '''
+        Check to see if we should send the
+        current batch.
+        True if timeout is > 10 or batch
+        size is reached. 
+        '''
+        now = time.time()
+        if (now - self.batch_time) > self.batch_timeout:
+            return True
+        elif self.batch_size > self.max_batch_size:
+            return True
+        return False
+
+    def forward(self):
         send_success = False
         while not send_success:
-            send_success = self.send_data(data)
+            send_success = self.send_data()
             if not send_success:
                 self.backoff = True
                 now = time.time()
@@ -81,22 +120,21 @@ class MetricForwarder(threading.Thread):
             self.backoff_sleep = 0
         return True
 
-    def send_data(self, data):
+    def send_data(self):
         try:
-            metric = data.metric
-            value = data.value
-            ts = data.timestamp
-        except AttributeError:
-            # somehow, this dp is invalid, pass it by.
-            return True
-
-        metric_str = "%s %s %s" % (metric, value, ts)
-        try:
-            self.request_session.post(self.url, data=metric_str,
-                                      stream=False)
+            req = self.request_session.post(self.url,
+                                          data=self.batch,
+                                          stream=False)
+            if req.status_code == 429:
+                logging.info("Metric forwarding limits hit, please contact support.")
         except Exception as e:
             logging.error("Metric forwarding exception was %s", e)
             return False
+        else:
+            # reset batch info now that send has succeeded.
+            self.batch = ""
+            self.batch_size = 0
+            self.batch_time = time.time()
         return True
 
     def shutdown(self):

--- a/hg_agent_forwarder/forwarder.py
+++ b/hg_agent_forwarder/forwarder.py
@@ -90,7 +90,7 @@ class MetricForwarder(threading.Thread):
         Check to see if we should send the
         current batch.
         True if timeout is > 10 or batch
-        size is reached. 
+        size is reached.
         '''
         now = time.time()
         if (now - self.batch_time) > self.batch_timeout:
@@ -123,10 +123,11 @@ class MetricForwarder(threading.Thread):
     def send_data(self):
         try:
             req = self.request_session.post(self.url,
-                                          data=self.batch,
-                                          stream=False)
+                                            data=self.batch,
+                                            stream=False)
             if req.status_code == 429:
-                logging.info("Metric forwarding limits hit, please contact support.")
+                logging.info("Metric forwarding limits hit \
+                             please contact support.")
         except Exception as e:
             logging.error("Metric forwarding exception was %s", e)
             return False

--- a/hg_agent_forwarder/forwarder.py
+++ b/hg_agent_forwarder/forwarder.py
@@ -79,11 +79,11 @@ class MetricForwarder(threading.Thread):
             ts = data.timestamp
         except AttributeError:
             # somehow, this dp is invalid, pass it by.
-            return True
-
-        metric_str = "%s %s %s" % (metric, value, ts)
-        self.batch = "%s\n%s" % (self.batch, metric_str)
-        self.batch_size += 1
+            pass
+        else:
+            metric_str = "%s %s %s" % (metric, value, ts)
+            self.batch = "%s\n%s" % (self.batch, metric_str)
+            self.batch_size += 1
 
     def should_send_batch(self):
         '''

--- a/hg_agent_forwarder/forwarder_main.py
+++ b/hg_agent_forwarder/forwarder_main.py
@@ -13,6 +13,8 @@ def main():
     metric_forwarder = MetricForwarder(config)
     metric_forwarder.start()
     while not shutdown.is_set():
+        if metric_forwarder.should_send_batch():
+            metric_forwarder.forward()
         time.sleep(5)
 
     logging.debug('Caught shutdown event')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests
+requests==2.18.1
 multitail2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 requirements = [
     'jsonschema==2.6.0',
-    'requests',
+    'requests==2.18.1',
     'rfc3987==1.3.7',  # For 'uri' format validation in jsonschema
     'supervisor==3.3.1',
     'PyYAML==3.12',
@@ -29,7 +29,7 @@ setup(
     long_description='Metric forwarder script for the Hosted Graphite agent.',
     author='Metricfire',
     author_email='maintainer@metricfire.com',
-    url='https://github.com/hostedgraphite/hg-agent-forwarder',
+    url='https://github.com/metricfire/hg-agent-forwarder',
     packages=find_packages(),
     package_data={},
     scripts=[],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,6 +111,10 @@ class MockedUdpRecvSocket(object):
                                       name, value)
 
 
+class Resp:
+    status_code = 200
+
+
 class FakeSession:
     def __init__(self, *args, **kwargs):
         self.connections = {}
@@ -128,7 +132,7 @@ class FakeSession:
         elif self.should_fail and self.is_called:
             pass
         self.metrics_posted.append(data)
-        return True
+        return Resp()
 
 
 class FakeSpool:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -31,9 +31,11 @@ class TestMetricForwarder(fake_filesystem_unittest.TestCase):
         self.setUpPyfakefs()
         self.fs.CreateDirectory('/var/opt/hg-agent')
         self.fs.CreateDirectory('/var/opt/hg-agent/spool/')
-        self.config = {'api-endpoint': "www.test.yolo",
-                       'apikey': API_KEY,
+        self.config = {'endpoint_url': "www.test.yolo",
+                       'api_key': API_KEY,
                        'spoolglob': "/var/opt/hg-agent/spool/*.spool.*",
+                       'batch_timeout': 2,
+                       'max_batch_size': 10
                        }
 
     def test_processing_metrics(self):
@@ -42,6 +44,8 @@ class TestMetricForwarder(fake_filesystem_unittest.TestCase):
         forwarder.request_session = FakeSession()
         forwarder.start()
         while len(forwarder.request_session.metrics_posted) < 10:
+            if forwarder.should_send_batch():
+                forwarder.forward()
             pass
         forwarder.shutdown()
         # we only have 10 valid metrics.
@@ -55,6 +59,8 @@ class TestMetricForwarder(fake_filesystem_unittest.TestCase):
         forwarder.request_session = FakeSession()
         forwarder.start()
         while len(forwarder.request_session.metrics_posted) < 10:
+            if forwarder.should_send_batch():
+                forwarder.forward()
             pass
         forwarder.shutdown()
         # we only have 10 valid metrics.
@@ -71,10 +77,13 @@ class TestMetricForwarder(fake_filesystem_unittest.TestCase):
         forwarder.error_timestamp = time.time()
         forwarder.start()
         while len(forwarder.request_session.metrics_posted) < 10:
+            if forwarder.should_send_batch():
+                forwarder.forward()
             time.sleep(0.1)
         forwarder.shutdown()
         metrics_posted = forwarder.request_session.metrics_posted
         invalid_posts = forwarder.request_session.invalid_posts
+
         self.assertFalse(forwarder.backoff)
         self.assertTrue(forwarder.request_session.is_called)
         self.assertEqual(len(metrics_posted), 10)
@@ -101,11 +110,9 @@ class TestMetricForwarder(fake_filesystem_unittest.TestCase):
 class TestMetricReceiverTcp(TestReceiver):
     def setUp(self):
         super(TestMetricReceiverTcp, self).setUp()
-        # mock out socket.
         self.config_sock = patch('hg_agent_forwarder.receiver.socket')
         self.mock_sock = self.config_sock.start()
         self.mock_sock.socket.return_value = MockedTcpRecvSocket()
-        # mock select.
         self.mock_sel = patch('hg_agent_forwarder.receiver.select')
         self.mocked_poll = self.mock_sel.start()
         self.mocked_poll.poll.return_value = mocked_poll
@@ -115,7 +122,6 @@ class TestMetricReceiverTcp(TestReceiver):
         tcp_receiver = MetricReceiverTcp(self.config)
         my_spool = tcp_receiver.spool
         tcp_receiver._sock.set_metric(self.test_metric, 20)
-        # begin test.
         setup_tcp_receiver(tcp_receiver)
         reciever_run_shutdown(tcp_receiver, 1)
         self.assertEqual(len(my_spool._spools), 1)
@@ -124,7 +130,6 @@ class TestMetricReceiverTcp(TestReceiver):
         tcp_receiver = MetricReceiverTcp(self.config)
         my_spool = tcp_receiver.spool
         [tcp_receiver._sock.set_metric(self.test_metric, 20) for _ in range(20)]
-        # begin test.
         setup_tcp_receiver(tcp_receiver)
         reciever_run_shutdown(tcp_receiver, 5)
         self.assertEqual(len(my_spool._spools), 1)
@@ -135,7 +140,6 @@ class TestMetricReceiverTcp(TestReceiver):
         tcp_receiver = MetricReceiverTcp(conf)
         my_spool = tcp_receiver.spool
         tcp_receiver._sock.set_metric(self.test_metric, 20)
-        # begin test.
         setup_tcp_receiver(tcp_receiver)
         time.sleep(2)
         tcp_receiver._sock.set_metric(self.test_metric, 20)
@@ -174,7 +178,6 @@ class TestMetricReceiverTcp(TestReceiver):
                                                     "foo.bar.baz",
                                                     20)
         tcp_receiver._sock.metric_count += 1
-        # begin test.
         setup_tcp_receiver(tcp_receiver)
         reciever_run_shutdown(tcp_receiver, 1)
         self.assertEqual(len(my_spool._spools), 1)
@@ -186,7 +189,6 @@ class TestMetricReceiverTcp(TestReceiver):
             write_spool(t)
         my_spool = tcp_receiver.spool
         tcp_receiver._sock.set_metric(self.test_metric, 20)
-        # begin test.
         setup_tcp_receiver(tcp_receiver)
         time.sleep(1)
         reciever_run_shutdown(tcp_receiver, 1)
@@ -203,7 +205,6 @@ class TestMetricReceiverTcp(TestReceiver):
             write_spool(t)
         my_spool = tcp_receiver.spool
         [tcp_receiver._sock.set_metric(self.test_metric, 20) for _ in range(4)]
-        # begin test.
         setup_tcp_receiver(tcp_receiver)
         while len(my_spool.lookup_spools()) > 10:
             tcp_receiver._sock.set_metric(self.test_metric, 20)
@@ -228,7 +229,6 @@ class TestMetricReceiverUdp(TestReceiver):
         my_spool = FakeSpool()
         udp_receiver = MetricReceiverUdp(self.config)
         udp_receiver._sock.set_metric(self.test_metric, 20)
-        # begin test.
         self.setup_udp_receiver(udp_receiver, my_spool)
         reciever_run_shutdown(udp_receiver, 1)
 
@@ -240,7 +240,6 @@ class TestMetricReceiverUdp(TestReceiver):
         my_spool = FakeSpool()
         udp_receiver = MetricReceiverUdp(self.config)
         [udp_receiver._sock.set_metric(self.test_metric, 20) for _ in range(10)]
-        # begin test.
         self.setup_udp_receiver(udp_receiver, my_spool)
         reciever_run_shutdown(udp_receiver, 10)
 
@@ -253,17 +252,17 @@ class TestMetricReceiverUdp(TestReceiver):
 class TestEndtoEnd(fake_filesystem_unittest.TestCase):
     def setUp(self):
         self.setUpPyfakefs()
-        self.config = {"tcp": {"port": 2003, "host": "localhost"},
-                       "apikey": API_KEY,
-                       "udp": {"port": 2003, "host": "localhost"},
-                       'api-endpoint': "www.test.yolo",
+        self.config = {"tcp_port": 2003,
+                       "api_key": API_KEY,
+                       "udp_port": 2003,
+                       'endpoint_url': "www.test.yolo",
                        'spoolglob': "/var/opt/hg-agent/spool/*.spool.*",
+                       'batch_timeout': 1
                        }
         self.test_metric = "foo.bar.baz"
         self.tcp_config_sock = patch('hg_agent_forwarder.receiver.socket')
         self.tcp_mock_sock = self.tcp_config_sock.start()
         self.tcp_mock_sock.socket.return_value = MockedTcpRecvSocket()
-        # mock select.
         self.mock_sel = patch('hg_agent_forwarder.receiver.select')
         self.mocked_poll = self.mock_sel.start()
         self.mocked_poll.poll.return_value = mocked_poll
@@ -273,16 +272,17 @@ class TestEndtoEnd(fake_filesystem_unittest.TestCase):
         tcp_config_sock = patch('hg_agent_forwarder.receiver.socket')
         tcp_mock_sock = self.tcp_config_sock.start()
         tcp_mock_sock.socket.return_value = MockedTcpRecvSocket()
-
         tcp_receiver = MetricReceiverTcp(self.config)
         my_spool = tcp_receiver.spool
         tcp_receiver._sock.set_metric(self.test_metric, 20)
-        # begin test.
         setup_tcp_receiver(tcp_receiver)
         forwarder = MetricForwarder(self.config)
         forwarder.request_session = FakeSession()
+
         forwarder.start()
         while len(forwarder.request_session.metrics_posted) < 1:
+            if forwarder.should_send_batch():
+                forwarder.forward()
             time.sleep(0.01)
         tcp_receiver.shutdown()
         self.assertEqual(len(my_spool.lookup_spools()), 1)
@@ -298,12 +298,14 @@ class TestEndtoEnd(fake_filesystem_unittest.TestCase):
         udp_receiver = MetricReceiverUdp(self.config)
         my_spool = udp_receiver.spool
         udp_receiver._sock.set_metric(self.test_metric, 20)
-        # begin test.
+
         udp_receiver.start()
         forwarder = MetricForwarder(self.config)
         forwarder.request_session = FakeSession()
         forwarder.start()
         while len(forwarder.request_session.metrics_posted) < 1:
+            if forwarder.should_send_batch():
+                forwarder.forward()
             time.sleep(0.01)
         udp_receiver.shutdown()
         self.assertEqual(len(my_spool.lookup_spools()), 1)


### PR DESCRIPTION
Batching metrics allows for increased throughput at high traffic volumes, a low flush rate allows for low levels of traffic to still be forwarded at a reasonable latency.

These config values are added to `hg-agent.conf` here:
https://github.com/hostedgraphite/hg-agent-periodic/pull/5

hg-agent version bump to follow.