### PR TITLE
remove unused udp sockopt, bump version

### DIFF
--- a/hg_agent_forwarder/receiver.py
+++ b/hg_agent_forwarder/receiver.py
@@ -24,9 +24,6 @@ class MetricReceiverUdp(threading.Thread):
         udp_socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 32768000)
         bufsize = udp_socket.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
         udp_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        # 15 is being used as socket.SO_REUSEPORT
-        # to allow multiprocess port sharing
-        udp_socket.setsockopt(socket.SOL_SOCKET, 15, 1)
         udp_socket.settimeout(0.1)
         host = self.config.get('udp_host', 'localhost')
         port = int(self.config.get('udp_port', 2003))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ dependency_links = [
 
 setup(
     name='hg-agent-forwarder',
-    version='1.0.1',
+    version='1.0.2',
     description='Metric forwarder script for the Hosted Graphite agent.',
     long_description='Metric forwarder script for the Hosted Graphite agent.',
     author='Metricfire',


### PR DESCRIPTION
So based on my understanding.. 
1. SO_REUSEPORT is only effective in a situation where we might want multiple UDP listeners binding to the same port. Therefore we shouldn't need it in the hg-agent. It is not intended for there to be multiple agents running on the same machine.

2. This actually causes the metric receiver to fail completely on a ubuntu 12.04 machine (possibly depending on the kernel). It, however, shouldn't have caused any issues on versions that support it.

Version bump in hg-agent repo to follow too.

Some info on this https://lwn.net/Articles/542629/