### PR TITLE
Handle CRLF in the TCP receiver

### DIFF
--- a/hg_agent_forwarder/receiver.py
+++ b/hg_agent_forwarder/receiver.py
@@ -52,7 +52,7 @@ class MetricReceiverUdp(threading.Thread):
 
             if data is not None:
                 for line in data.strip("\n").split("\n"):
-                    line = line.strip()
+                    line = line.strip() # Handle CRLF as well as lone LF
                     try:
                         datapoint = Datapoint(line, self.api_key)
                         datapoint.key_strip()
@@ -169,6 +169,7 @@ class MetricReceiverTcp(threading.Thread):
                         # line we just read.
                         this_buf = self._buffers[fd]
                         (line, self._buffers[fd]) = this_buf.split("\n", 1)
+                        line = line.strip() # Handle CRLF as well as lone LF
                         try:
                             self._process(line)
                         except Exception, ex:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ dependency_links = [
 
 setup(
     name='hg-agent-forwarder',
-    version='1.0.2',
+    version='1.0.3',
     description='Metric forwarder script for the Hosted Graphite agent.',
     long_description='Metric forwarder script for the Hosted Graphite agent.',
     author='Metricfire',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,10 +68,10 @@ class MockedTcpRecvSocket(object):
     def bind(self, *args, **kwargs):
         pass
 
-    def set_metric(self, name, value):
+    def set_metric(self, name, value, lf='\n'):
         self.metric_count += 1
-        self.metric = "%s.%s %s\n" % (self._api_key,
-                                      name, value)
+        self.metric = "%s.%s %s%s" % (self._api_key,
+                                      name, value, lf)
 
 
 class MockedUdpRecvSocket(object):
@@ -105,10 +105,10 @@ class MockedUdpRecvSocket(object):
     def bind(self, *args, **kwargs):
         pass
 
-    def set_metric(self, name, value):
+    def set_metric(self, name, value, lf='\n'):
         self.metric_count += 1
-        self.metric = "%s.%s %s\n" % (self._api_key,
-                                      name, value)
+        self.metric = "%s.%s %s%s" % (self._api_key,
+                                      name, value, lf)
 
 
 class Resp:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -126,6 +126,14 @@ class TestMetricReceiverTcp(TestReceiver):
         reciever_run_shutdown(tcp_receiver, 1)
         self.assertEqual(len(my_spool._spools), 1)
 
+    def test_tcp_crlf_dp(self):
+        tcp_receiver = MetricReceiverTcp(self.config)
+        my_spool = tcp_receiver.spool
+        tcp_receiver._sock.set_metric(self.test_metric, 20, lf='\r\n')
+        setup_tcp_receiver(tcp_receiver)
+        reciever_run_shutdown(tcp_receiver, 1)
+        self.assertEqual(len(my_spool._spools), 1)
+
     def test_tcp_multi_dp(self):
         tcp_receiver = MetricReceiverTcp(self.config)
         my_spool = tcp_receiver.spool
@@ -235,6 +243,14 @@ class TestMetricReceiverUdp(TestReceiver):
         self.assertEqual(len(my_spool.metrics), 1)
         self.assertEqual(my_spool.metrics[0].metric, "%s.foo.bar.baz" % API_KEY)
         self.assertEqual(my_spool.metrics[0].value, 20)
+
+    def test_udp_crlf_dp(self):
+        my_spool = FakeSpool()
+        udp_receiver = MetricReceiverUdp(self.config)
+        udp_receiver._sock.set_metric(self.test_metric, 20, '\r\n')
+        self.setup_udp_receiver(udp_receiver, my_spool)
+        reciever_run_shutdown(udp_receiver, 1)
+        self.assertEqual(len(my_spool.metrics), 1)
 
     def test_udp_multi_dp(self):
         my_spool = FakeSpool()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -247,7 +247,7 @@ class TestMetricReceiverUdp(TestReceiver):
     def test_udp_crlf_dp(self):
         my_spool = FakeSpool()
         udp_receiver = MetricReceiverUdp(self.config)
-        udp_receiver._sock.set_metric(self.test_metric, 20, '\r\n')
+        udp_receiver._sock.set_metric(self.test_metric, 20, lf='\r\n')
         self.setup_udp_receiver(udp_receiver, my_spool)
         reciever_run_shutdown(udp_receiver, 1)
         self.assertEqual(len(my_spool.metrics), 1)


### PR DESCRIPTION
`'\r\n'` is generated as a newline by various tools including `collectd`

Somewhere along the way we dropped handling for this in hg-agent's TCP
receiver.

This change fixes that & notes the purpose of the additional `strip()`
in both receivers.