### PR TITLE
Fix spool file rotation on restart

### DIFF
--- a/hg_agent_forwarder/utils.py
+++ b/hg_agent_forwarder/utils.py
@@ -181,7 +181,8 @@ class Spool:
     def lookup_spools(self):
         all_spools = []
         for f in glob.glob('/var/opt/hg-agent/spool/*.spool.*'):
-            all_spools.append(f.split('.')[2])
+            ts = int(f.split('.')[2])
+            all_spools.append(ts)
         return all_spools
 
     def delete_spool(self, ts):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ dependency_links = [
 
 setup(
     name='hg-agent-forwarder',
-    version='1.0.3',
+    version='1.0.4',
     description='Metric forwarder script for the Hosted Graphite agent.',
     long_description='Metric forwarder script for the Hosted Graphite agent.',
     author='Metricfire',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -200,7 +200,11 @@ class TestMetricReceiverTcp(TestReceiver):
         setup_tcp_receiver(tcp_receiver)
         time.sleep(1)
         reciever_run_shutdown(tcp_receiver, 1)
-        self.assertEqual(len(my_spool.lookup_spools()), 10)
+
+        all_spools = my_spool.lookup_spools()
+        for ts in all_spools:
+            self.assertIsInstance(ts, int)
+        self.assertEqual(len(all_spools), 10)
 
     @patch('hg_agent_forwarder.utils.fcntl.flock')
     def test_too_many_spools_rotate_bytes(self, fl):


### PR DESCRIPTION
On restart, `Spool.flush_spools()` reads in existing spool files from
the filesystem.

Unfortunately, it reads the timestamps for them as strings. Any new
spool files are created with integer timestamps, which always sort as
"earlier than" the string spools.

This can mean that the most recently created spoolfile is unlinked by
`flush_spools()`, repeatedly.