### PR TITLE
Correct forwarder shutdown & exponential backoff

### DIFF
--- a/hg_agent_forwarder/forwarder.py
+++ b/hg_agent_forwarder/forwarder.py
@@ -106,6 +106,9 @@ class MetricForwarder(threading.Thread):
     def forward(self):
         send_success = False
         while not send_success:
+            if self.shutdown_e.is_set():
+                break
+
             send_success = self.send_data()
             if not send_success:
                 self.backoff = True

--- a/hg_agent_forwarder/forwarder_main.py
+++ b/hg_agent_forwarder/forwarder_main.py
@@ -11,16 +11,16 @@ def main():
     shutdown = create_shutdown_event()
     logging.info("Metric forwarder starting.")
 
-    metric_forwarder = MetricForwarder(config)
+    metric_forwarder = MetricForwarder(config, shutdown)
     metric_forwarder.start()
     while not shutdown.is_set():
         if metric_forwarder.should_send_batch():
             metric_forwarder.forward()
         time.sleep(5)
 
-    logging.debug('Caught shutdown event')
+    logging.info("Metric forwarder shutting down")
     metric_forwarder.shutdown()
-    logging.info("Metric forwarder shutdown.")
+    logging.info("Metric forwarder finished.")
 
 if __name__ == '__main__':
     main()

--- a/hg_agent_forwarder/forwarder_main.py
+++ b/hg_agent_forwarder/forwarder_main.py
@@ -9,6 +9,7 @@ def main():
     config = load_config('forwarder', str(args.config))
     init_log('hg-agent-forwarder', args.debug)
     shutdown = create_shutdown_event()
+    logging.info("Metric forwarder starting.")
 
     metric_forwarder = MetricForwarder(config)
     metric_forwarder.start()
@@ -18,14 +19,8 @@ def main():
         time.sleep(5)
 
     logging.debug('Caught shutdown event')
-
-    # Shutdown forwarder
-    while metric_forwarder.is_alive():
-        metric_forwarder.shutdown()
-        metric_forwarder.join(timeout=0.1)
-        time.sleep(0.1)
-
-    logging.info("Metric forwarder closed.")
+    metric_forwarder.shutdown()
+    logging.info("Metric forwarder shutdown.")
 
 if __name__ == '__main__':
     main()

--- a/hg_agent_forwarder/receiver.py
+++ b/hg_agent_forwarder/receiver.py
@@ -48,9 +48,9 @@ class MetricReceiverUdp(threading.Thread):
                 if num not in [4, 11]:
                     raise
             except TypeError as e:
-                logging.error("UDP receiver error was %s", e)
+                logging.error("UDP receiver error: %s", e)
 
-            if data is not None:
+            if data:
                 for line in data.strip("\n").split("\n"):
                     line = line.strip() # Handle CRLF as well as lone LF
                     try:

--- a/hg_agent_forwarder/utils.py
+++ b/hg_agent_forwarder/utils.py
@@ -195,7 +195,7 @@ class Spool:
             pass
 
         for f in glob.glob('/var/opt/hg-agent/spool/*.spool.%s' % ts):
-            logging.info("Deleteing spool file %s" % f)
+            logging.info("Deleting spool file %s" % f)
             try:
                 os.remove(f)
                 self._all_spools.remove(ts)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -128,7 +128,7 @@ class FakeSession:
         self.is_called = False
         self.invalid_posts = []
 
-    def post(self, url, data=None, stream=False):
+    def post(self, url, data=None, stream=False, timeout=None):
         if self.should_fail and not self.is_called:
             self.is_called = True
             self.invalid_posts.append(data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,6 +86,7 @@ class MockedUdpRecvSocket(object):
             time.sleep(0.01)
             self.metrics_sent += 1
             return self.metric, ""
+        return "", ""
 
     def close(self, *args, **kwargs):
         pass
@@ -113,6 +114,9 @@ class MockedUdpRecvSocket(object):
 
 class Resp:
     status_code = 200
+
+    def raise_for_status(self):
+        pass
 
 
 class FakeSession:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -86,7 +86,6 @@ class TestMetricForwarder(fake_filesystem_unittest.TestCase):
         forwarder = MetricForwarder(self.config, self.shutdown)
         forwarder.request_session = FakeSession()
         forwarder.request_session.should_fail = True
-        forwarder.error_timestamp = time.time()
         forwarder.start()
         while len(forwarder.request_session.metrics_posted) < 10:
             forwarder.forward()
@@ -96,10 +95,8 @@ class TestMetricForwarder(fake_filesystem_unittest.TestCase):
         metrics_posted = forwarder.request_session.metrics_posted
         invalid_posts = forwarder.request_session.invalid_posts
 
-        self.assertFalse(forwarder.backoff)
         self.assertTrue(forwarder.request_session.is_called)
         self.assertEqual(len(metrics_posted), 10)
-        self.assertEqual(forwarder.backoff_sleep, 0)
         self.assertEqual(len(invalid_posts), 1)
         self.assertIn(invalid_posts[0], metrics_posted)
         self.remove_spool(filename)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = py27
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}/hg_agent_forwarder
-commands = nosetests -s --with-coverage --cover-package=hg_agent_forwarder --cover-html {posargs}
+commands = nosetests -v --nologcapture -s --with-coverage --cover-package=hg_agent_forwarder --cover-html {posargs}
 
 deps =
     mock


### PR DESCRIPTION
Two parts (it grew in the telling ...):

*   Fix `forwarder` hang while attempting to shutdown.
    
    Because `multitail2` can block indefinitely, once the `receiver` is
    down, `forwarder` must not try to `join()` the spool-reading thread
    (i.e. `MetricForwarder`). Since it is a `daemon` thread, it will just
    exit with the interpreter - and that's fine.

    Getting this to work properly ended up being a bit more involved
    than I expected, but the changes should be easy to understand.

*   Simplify backoff & make it exponential w/jitter

    The existing backoff algorithm ends up sleeping as long as a
    connectivity issue has been, and does a simple linear count; we can
    envisage a "thundering herd" of agent clients all sending their data at
    once, and delayed more than it has to be.

    This approach (which is also easier to read) backs off exponentially
    with a ceiling, and adds some initial randomness.

Also comments describing how this works, plus some logging changes.