### PR TITLE
Bugfix: Remove second call of the forwarder

### DIFF
--- a/hg_agent_forwarder/forwarder_main.py
+++ b/hg_agent_forwarder/forwarder_main.py
@@ -14,8 +14,6 @@ def main():
     metric_forwarder = MetricForwarder(config, shutdown)
     metric_forwarder.start()
     while not shutdown.is_set():
-        if metric_forwarder.should_send_batch():
-            metric_forwarder.forward()
         time.sleep(5)
 
     logging.info("Metric forwarder shutting down")

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ dependency_links = [
 
 setup(
     name='hg-agent-forwarder',
-    version='1.0.4',
+    version='1.0.5',
     description='Metric forwarder script for the Hosted Graphite agent.',
     long_description='Metric forwarder script for the Hosted Graphite agent.',
     author='Metricfire',


### PR DESCRIPTION
The forward method was being called twice due to a race condition where two occurrences of `should_send_batch` get executed at the same time, resulting in both returning `true`. Then, because the forward function isn't thread-safe, both calls to the method pump the _same datapoints_ which leads to duplicates.

The other location of execution: https://github.com/hostedgraphite/hg-agent-forwarder/blob/master/hg_agent_forwarder/forwarder.py#L68-L69